### PR TITLE
Allow to use BasicAuth to send the shelly password

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Use `target` to define which shelly to query.
 You may use an IP or a domain name.
 You may configure a port like this `name:port`.
 
-If your Shelly is password protected,
-you may use the `username` and `password` arguments to pass credentials.
+If your Shelly is password protected, use basic auth to send the username and password.
+For backward compatibility, the query parameter `username` and `password` will also work.
 
 ## TODO
 

--- a/shelly-openmetrics-exporter.go
+++ b/shelly-openmetrics-exporter.go
@@ -41,8 +41,12 @@ func probeHandler(w http.ResponseWriter, req *http.Request) {
 		http.Error(w, "'target' parameter is missing", http.StatusBadRequest)
 		return
 	}
-	username := req.URL.Query().Get("username")
-	password := req.URL.Query().Get("password")
+
+	username, password, ok := req.BasicAuth()
+	if !ok {
+		username = req.URL.Query().Get("username")
+		password = req.URL.Query().Get("password")
+	}
 
 	shellyType, err := shelly_detect.DetectVersion(target)
 	if err != nil {


### PR DESCRIPTION
Sending username and password within the query parameter is insecure. It may leak the password in access logs and won't work within the [`Probe`](https://prometheus-operator.dev/docs/operator/design/#probe) CRD of the prometheus operator.

The better solution is to accept the authentication information using basic auth and forward them to the shelly device.